### PR TITLE
feat(pomodoro): Flaskアプリの初期実装を追加

### DIFF
--- a/1.pomodoro/app.py
+++ b/1.pomodoro/app.py
@@ -1,1 +1,29 @@
-# Pomodoro Timer App
+from flask import Flask, render_template
+from config import Config
+from database import init_db
+
+
+def create_app(config=None):
+    """アプリケーションファクトリ"""
+    app = Flask(__name__)
+
+    # 設定を読み込む（デフォルトは Config）
+    if config is None:
+        app.config.from_object(Config)
+    else:
+        app.config.from_object(config)
+
+    # DB 初期化
+    init_db(app)
+
+    # ルート定義
+    @app.route("/")
+    def index():
+        return render_template("index.html")
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(debug=True)

--- a/1.pomodoro/architecture.md
+++ b/1.pomodoro/architecture.md
@@ -1,0 +1,162 @@
+# ポモドーロタイマー Web アプリ アーキテクチャ案
+
+## 技術スタック
+
+| 用途 | 技術 |
+|---|---|
+| サーバー | Flask + Flask-SQLAlchemy |
+| DB | SQLite |
+| フロントエンド | Vanilla JS + CSS Variables |
+| 円形プログレス | SVG `<circle>` + `stroke-dashoffset` |
+
+---
+
+## ディレクトリ構成
+
+```
+1.pomodoro/
+├── app.py                          # create_app() ファクトリのみ（薄く保つ）
+├── config.py                       # 環境別設定（本番 / テスト）
+├── models.py                       # SQLAlchemy データモデル
+├── database.py                     # DB 初期化・接続ユーティリティ
+├── pomodoro.db                     # SQLite データベース（自動生成）
+├── services/
+│   └── session_service.py          # ビジネスロジック（Flask 非依存）
+├── repositories/
+│   └── session_repo.py             # DB アクセスの抽象化
+├── static/
+│   ├── css/
+│   │   └── style.css               # UI スタイル（グラデーション・円形プログレス）
+│   └── js/
+│       ├── timer_core.js           # 純粋なタイマー状態管理（DOM 依存なし）
+│       └── timer_ui.js             # DOM 操作・イベントバインド
+├── templates/
+│   └── index.html                  # メイン画面テンプレート
+└── tests/
+    ├── conftest.py                  # 共通 pytest フィクスチャ
+    ├── test_session_service.py      # サービスレイヤーのユニットテスト
+    ├── test_session_repo.py         # リポジトリのユニットテスト
+    └── test_routes.py              # Flask ルートの統合テスト
+```
+
+---
+
+## レイヤー構成と責務
+
+### バックエンド
+
+#### `app.py` — ルーティング
+
+`create_app(config)` ファクトリパターンを採用し、環境に応じた設定を注入できるようにする。
+ルートハンドラはサービスレイヤーを呼び出すだけに留め、ロジックを持たせない。
+
+| エンドポイント | メソッド | 役割 |
+|---|---|---|
+| `/` | GET | メイン画面表示 |
+| `/api/session` | POST | ポモドーロ完了を記録 |
+| `/api/stats/today` | GET | 今日の完了数・集中時間を返す |
+| `/api/settings` | GET / POST | タイマー設定の取得・保存 |
+
+#### `services/session_service.py` — ビジネスロジック
+
+Flask に依存せず、ビジネスルールのみを担当する。
+依存性注入（DI）パターンで `SessionRepository` を受け取る。
+
+```python
+class SessionService:
+    def __init__(self, repo: SessionRepository):
+        self.repo = repo
+
+    def complete_session(self, duration: int) -> dict: ...
+    def get_today_stats(self) -> dict: ...
+```
+
+#### `repositories/session_repo.py` — DB アクセス抽象化
+
+DB 操作をインターフェースとして切り出す。
+テスト時はモックに差し替えることで DB なしでサービスのテストが可能。
+
+#### `config.py` — 環境別設定
+
+```python
+class Config:
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///pomodoro.db'
+    TESTING = False
+
+class TestingConfig(Config):
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'  # インメモリDB
+    TESTING = True
+```
+
+#### `models.py` — データモデル
+
+```
+Session テーブル
+├── id          INTEGER PRIMARY KEY
+├── started_at  DATETIME
+├── type        TEXT  ('work' | 'break')
+├── duration    INTEGER  # 秒
+└── completed   BOOLEAN
+```
+
+---
+
+### フロントエンド
+
+#### `timer_core.js` — 純粋なタイマーロジック
+
+DOM に一切依存しない状態管理クラス。Jest 等でブラウザなしにユニットテストできる。
+
+```javascript
+export class PomodoroTimer {
+    // 状態: IDLE / RUNNING / BREAK / PAUSED
+    start()     { ... }
+    reset()     { ... }
+    tick()      { ... }  // 1秒進める純粋関数
+    getState()  { return { remaining, phase, ... } }
+}
+```
+
+#### `timer_ui.js` — DOM 操作・イベントバインド
+
+`PomodoroTimer` のインスタンスを受け取り、状態変化を画面に反映する。
+開始・リセットボタンのイベント登録、SVG プログレスバーの更新、API 呼び出しを担当。
+
+#### 円形プログレスバー
+
+SVG の `<circle>` 要素に `stroke-dashoffset` を CSS アニメーションで操作して描画する。
+外部 UI ライブラリは不要。
+
+---
+
+## タイマーの状態遷移
+
+```
+         開始ボタン
+IDLE ──────────────→ RUNNING
+ ↑                      │
+ │  リセットボタン        │ タイマー満了
+ │                      ↓
+ ├──────────────── BREAK（休憩）
+ │  リセットボタン        │ タイマー満了
+ │                      │
+ └────────────────────←─┘
+
+RUNNING / BREAK 中に一時停止ボタン → PAUSED
+PAUSED 中に再開ボタン → 元の状態に戻る
+```
+
+セッション完了（RUNNING → BREAK 遷移時）に `POST /api/session` を呼び出して記録する。
+
+---
+
+## テスト戦略
+
+| テスト対象 | 手法 | ポイント |
+|---|---|---|
+| `session_service.py` | pytest + `MagicMock` | `repo` をモックに差し替え、Flask・DB 不要 |
+| `session_repo.py` | pytest + `TestingConfig` | SQLite インメモリ DB を使用 |
+| `test_routes.py` | Flask test client | `create_app(TestingConfig)` でインメモリ DB |
+| `timer_core.js` | Jest | DOM 依存なしで純粋ロジックをテスト |
+
+`tests/conftest.py` に共通フィクスチャ（アプリインスタンス・DBセットアップ）を集約し、テストコードの重複を排除する。

--- a/1.pomodoro/config.py
+++ b/1.pomodoro/config.py
@@ -1,0 +1,16 @@
+import os
+
+
+class Config:
+    """本番用設定"""
+    BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{os.path.join(BASE_DIR, 'pomodoro.db')}"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    TESTING = False
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
+
+
+class TestingConfig(Config):
+    """テスト用設定（インメモリ DB）"""
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    TESTING = True

--- a/1.pomodoro/database.py
+++ b/1.pomodoro/database.py
@@ -1,0 +1,11 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# SQLAlchemy インスタンス（アプリ全体で共有）
+db = SQLAlchemy()
+
+
+def init_db(app):
+    """アプリケーションに DB を初期化する"""
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()

--- a/1.pomodoro/features.md
+++ b/1.pomodoro/features.md
@@ -1,0 +1,53 @@
+# ポモドーロタイマー 実装機能一覧
+
+## バックエンド
+
+### アプリケーション基盤
+- [ ] `config.py` — 本番用・テスト用の設定クラス（`Config` / `TestingConfig`）
+- [ ] `database.py` — SQLAlchemy インスタンスの初期化・DB 接続ユーティリティ
+- [ ] `models.py` — `Session` テーブル（id, started_at, type, duration, completed）
+- [ ] `app.py` — `create_app()` ファクトリパターン・ルート定義
+
+### API エンドポイント
+- [ ] `GET /` — メイン画面（index.html）の返却
+- [ ] `POST /api/session` — ポモドーロ完了を DB に記録
+- [ ] `GET /api/stats/today` — 今日の完了数・集中時間の集計・返却
+- [ ] `GET /POST /api/settings` — タイマー設定（作業時間・休憩時間）の取得・保存
+
+### ビジネスロジック / DB アクセス
+- [ ] `services/session_service.py` — `complete_session()` / `get_today_stats()` の実装
+- [ ] `repositories/session_repo.py` — DB アクセスの抽象化（DI 対応）
+
+---
+
+## フロントエンド
+
+### タイマーロジック（`timer_core.js`）
+- [ ] タイマー状態管理（IDLE / RUNNING / BREAK / PAUSED）
+- [ ] `start()` / `reset()` / `tick()` / `getState()` の実装
+- [ ] RUNNING → BREAK の自動遷移（タイマー満了検知）
+- [ ] PAUSED 状態のトグル（一時停止 / 再開）
+
+### UI / DOM 操作（`timer_ui.js`）
+- [ ] 残り時間の表示更新（`MM:SS` フォーマット）
+- [ ] 開始・リセットボタンのイベントバインド
+- [ ] フェーズラベルの表示切り替え（「作業中」/「休憩中」）
+- [ ] セッション完了時に `POST /api/session` を呼び出し
+- [ ] ページ表示時に `GET /api/stats/today` を呼び出して進捗を更新
+
+### 円形プログレスバー（`index.html` + `style.css`）
+- [ ] SVG `<circle>` による円形プログレスの描画
+- [ ] `stroke-dashoffset` のアニメーション更新（残り時間に連動）
+
+### 今日の進捗パネル
+- [ ] 「完了セッション数」の表示
+- [ ] 「集中時間（時間・分）」の表示
+
+---
+
+## テスト
+
+- [ ] `tests/conftest.py` — アプリインスタンス・インメモリ DB の共通フィクスチャ
+- [ ] `tests/test_session_service.py` — `MagicMock` を使ったサービスのユニットテスト
+- [ ] `tests/test_session_repo.py` — リポジトリのユニットテスト
+- [ ] `tests/test_routes.py` — Flask test client を使った統合テスト

--- a/1.pomodoro/models.py
+++ b/1.pomodoro/models.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from database import db
+
+
+class Session(db.Model):
+    """ポモドーロセッションモデル"""
+    __tablename__ = "sessions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    started_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    type = db.Column(db.String(10), nullable=False, default="work")  # 'work' | 'break'
+    duration = db.Column(db.Integer, nullable=False)  # 秒
+    completed = db.Column(db.Boolean, nullable=False, default=False)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "started_at": self.started_at.isoformat(),
+            "type": self.type,
+            "duration": self.duration,
+            "completed": self.completed,
+        }
+
+    def __repr__(self):
+        return f"<Session id={self.id} type={self.type} completed={self.completed}>"

--- a/1.pomodoro/planning.md
+++ b/1.pomodoro/planning.md
@@ -1,0 +1,88 @@
+# ポモドーロタイマー 段階的実装計画
+
+## Phase 1 — バックエンド基盤（依存なし・最小構成）
+
+**目標:** Flask が起動し、トップページが返せる状態にする
+
+- [ ] `config.py` — `Config` / `TestingConfig` クラス
+- [ ] `database.py` — SQLAlchemy インスタンス初期化
+- [ ] `models.py` — `Session` モデル定義
+- [ ] `app.py` — `create_app()` ファクトリ + `GET /` ルート
+- [ ] `templates/index.html` — 最小限の骨格 HTML（スタイルなし）
+
+**完了の確認:** `flask run` でトップページが表示される
+
+---
+
+## Phase 2 — DB アクセス層 + ビジネスロジック層
+
+**目標:** ロジックを独立したモジュールに分離し、テスト可能にする
+
+- [ ] `repositories/session_repo.py` — `SessionRepository`（`add_session` / `get_today_sessions`）
+- [ ] `services/session_service.py` — `SessionService`（`complete_session` / `get_today_stats`）
+
+**完了の確認:** Python REPL でサービスを単体で呼び出せる
+
+---
+
+## Phase 3 — REST API 実装
+
+**目標:** フロントからデータを記録・取得できる API を揃える
+
+- [ ] `POST /api/session` — セッション完了の記録
+- [ ] `GET /api/stats/today` — 今日の集計値を返す
+- [ ] `GET|POST /api/settings` — 設定の取得・保存
+
+**完了の確認:** `curl` や HTTPie で各エンドポイントが正常応答する
+
+---
+
+## Phase 4 — フロントエンド タイマーロジック
+
+**目標:** DOM に依存しない純粋なタイマー状態管理を作る
+
+- [ ] `static/js/timer_core.js` — `PomodoroTimer` クラス
+  - 状態: `IDLE / RUNNING / BREAK / PAUSED`
+  - `start()` / `reset()` / `tick()` / `getState()`
+  - RUNNING → BREAK 自動遷移・PAUSED トグル
+
+**完了の確認:** ブラウザコンソールで `new PomodoroTimer()` を操作できる
+
+---
+
+## Phase 5 — UI 実装（デザインの再現）
+
+**目標:** 設計画像のデザインを忠実に実装する
+
+- [ ] `static/css/style.css` — グラデーション背景・ウィンドウ風カード・CSS Variables
+- [ ] `templates/index.html` — SVG 円形プログレスバー・ボタン・進捗パネル
+- [ ] `static/js/timer_ui.js` — DOM バインド・残り時間表示・API 呼び出し
+
+**完了の確認:** ブラウザで開始 → カウントダウン → 休憩遷移が動作する
+
+---
+
+## Phase 6 — テスト整備
+
+**目標:** 各レイヤーを自動テストでカバーする
+
+- [ ] `tests/conftest.py` — 共通フィクスチャ（インメモリ DB・テスト用アプリ）
+- [ ] `tests/test_session_service.py` — `MagicMock` でリポジトリを差し替え
+- [ ] `tests/test_session_repo.py` — インメモリ DB でリポジトリをテスト
+- [ ] `tests/test_routes.py` — Flask test client で API を統合テスト
+
+---
+
+## 実装順序の補足
+
+```
+Phase 1 → Phase 2 → Phase 3  ← バックエンドを先に固める
+                ↓
+           Phase 4            ← フロントの純粋ロジックを独立して作る
+                ↓
+           Phase 5            ← UI は API と timer_core.js が揃ってから
+                ↓
+           Phase 6            ← 各レイヤー完成後に並行で書ける
+```
+
+> **Note:** Phase 2 と Phase 4 は互いに独立しているため、並行作業も可能。

--- a/1.pomodoro/templates/index.html
+++ b/1.pomodoro/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ポモドーロタイマー</title>
+</head>
+<body>
+    <h1>ポモドーロタイマー</h1>
+    <p>Phase 1 — バックエンド基盤 完了</p>
+</body>
+</html>


### PR DESCRIPTION
- app.py: アプリケーションファクトリパターンでFlaskアプリを構築
- config.py: アプリケーション設定クラスを追加
- database.py: データベース初期化処理を追加
- models.py: データモデルを追加
- templates/index.html: トップページのHTMLテンプレートを追加
- planning.md / features.md / architecture.md: 設計・機能ドキュメントを追加

This pull request establishes the foundational backend structure for the Pomodoro Timer web application. It introduces a modular Flask application using the application factory pattern, sets up environment-specific configuration, initializes the database with SQLAlchemy, and defines the initial data model. Additionally, it includes architecture and planning documentation to guide further development phases.